### PR TITLE
Number support

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "project": {
-    "name": "ngx-duration-picker"
+    "name": "ngxd-duration-picker"
   },
   "apps": [
     {
@@ -17,7 +17,7 @@
       "test": "test.ts",
       "tsconfig": "tsconfig.app.json",
       "testTsconfig": "tsconfig.spec.json",
-      "prefix": "app",
+      "prefix": "ngxd",
       "styles": [
         "../node_modules/bootstrap/dist/css/bootstrap.min.css",
         "styles.css"

--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "project": {
-    "name": "ngxd-duration-picker"
+    "name": "ngx-duration-picker"
   },
   "apps": [
     {
@@ -17,7 +17,7 @@
       "test": "test.ts",
       "tsconfig": "tsconfig.app.json",
       "testTsconfig": "tsconfig.spec.json",
-      "prefix": "ngxd",
+      "prefix": "ngx",
       "styles": [
         "../node_modules/bootstrap/dist/css/bootstrap.min.css",
         "styles.css"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ export class AppModule { }
 
 ## Usage
 
-```<ngxd-duration-picker [(value)]="myDuration"></ngxd-duration-picker>```
+```<ngx-duration-picker [(value)]="myDuration"></ngx-duration-picker>```
 
 where **myDuration** will be the variable where the output is stored, you can also pass an initial value.
 
@@ -39,13 +39,13 @@ where **myDuration** will be the variable where the output is stored, you can al
 
 if you need to perform some operations each time the bound variable changes, you can use `(valueChange)`:
 
-```<ngxd-duration-picker [(value)]="myDuration" (valueChange)="doSomeStuff()">```
+```<ngx-duration-picker [(value)]="myDuration" (valueChange)="doSomeStuff()">```
 
 ### Passing options
 
 you can pass specify some options by binding `[options]` to your configuration object:
 
-```<ngxd-duration-picker [(value)]="myDuration" [options]="{ showWeeks: false }" mode="seconds">```
+```<ngx-duration-picker [(value)]="myDuration" [options]="{ showWeeks: false }" mode="seconds">```
 
 ### Available options
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ if you need to perform some operations each time the bound variable changes, you
 
 you can pass specify some options by binding `[options]` to your configuration object:
 
-```<ngx-duration-picker [(value)]="myDuration" [options]="{ showWeeks: false }" mode="seconds">```
+```<ngx-duration-picker [(value)]="myDuration" [options]="{ showWeeks: false, mode: 'seconds' }">```
 
 ### Available options
 
@@ -87,10 +87,9 @@ Boolean, default `true`. Shows the minutes, when hidden it will be always consid
 #### showSeconds
 Boolean, default `true`. Shows the seconds, when hidden it will be always considered as 0.
 
-### Mode options
+#### mode
+`'ISO_8601'` | `'seconds'` | `'minutes'` | `'hours'` | `'days'` | `'weeks'` | `'months'` | `'years'`, default `'ISO_8601'`. 
 
-#### ISO_8601 (default)
-The default mode where the input and output value are in [ISO_8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+Specify `ISO_8601` if the desired input and output values are [ISO_8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations).
 
-#### seconds/minutes/hours/days/weeks/months/years
-Specify one of these types if you would for example like to input and output seconds instead of ISO 8601 durations.
+Specify one of the other types if you would for example like to input and output seconds instead of ISO 8601 durations.

--- a/README.md
+++ b/README.md
@@ -86,3 +86,11 @@ Boolean, default `true`. Shows the minutes, when hidden it will be always consid
 
 #### showSeconds
 Boolean, default `true`. Shows the seconds, when hidden it will be always considered as 0.
+
+### Mode options
+
+#### ISO_8601 (default)
+The default mode where the input and output value are in [ISO_8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+
+#### seconds/minutes/hours/days/weeks/months/years
+Specify one of these types if you would for example like to input and output seconds instead of ISO 8601 durations.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ export class AppModule { }
 
 ## Usage
 
-```<app-duration-picker [(value)]="myDuration"></app-duration-picker>```
+```<ngxd-duration-picker [(value)]="myDuration"></ngxd-duration-picker>```
 
 where **myDuration** will be the variable where the output is stored, you can also pass an initial value.
 
@@ -39,13 +39,13 @@ where **myDuration** will be the variable where the output is stored, you can al
 
 if you need to perform some operations each time the bound variable changes, you can use `(valueChange)`:
 
-```<app-duration-picker [(value)]="myDuration" (valueChange)="doSomeStuff()">```
+```<ngxd-duration-picker [(value)]="myDuration" (valueChange)="doSomeStuff()">```
 
 ### Passing options
 
 you can pass specify some options by binding `[options]` to your configuration object:
 
-```<app-duration-picker [(value)]="myDuration" [options]="{ showWeeks: false }">```
+```<ngxd-duration-picker [(value)]="myDuration" [options]="{ showWeeks: false }" mode="seconds">```
 
 ### Available options
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,7 +3,7 @@
     <div class="col-xs-12">
       <div class="h1">Plain binding</div>
 
-      <ngxd-duration-picker [(value)]="myValue" [disabled]="disabled"></ngxd-duration-picker>
+      <ngx-duration-picker [(value)]="myValue" [disabled]="disabled"></ngx-duration-picker>
 
     </div>
     <div class="col-xs-6">
@@ -23,7 +23,7 @@
     <div class="col-xs-12">
       <div class="h1">Reactive Form</div>
       <form [formGroup]="form">
-        <ngxd-duration-picker [formControlName]="'myDurationControl'"></ngxd-duration-picker>
+        <ngx-duration-picker [formControlName]="'myDurationControl'"></ngx-duration-picker>
       </form>
     </div>
 
@@ -57,7 +57,7 @@
       <div class="col-xs-12">
         <div class="h1">Negative Duration</div>
 
-        <ngxd-duration-picker [(value)]="myNegativeValue" [options]="{ showNegative: showNegative }"></ngxd-duration-picker>
+        <ngx-duration-picker [(value)]="myNegativeValue" [options]="{ showNegative: showNegative }"></ngx-duration-picker>
 
       </div>
       <div class="col-xs-6">
@@ -78,7 +78,7 @@
   <div class="row">
     <div class="col-xs-12">
       <div class="h1">Numeric mode</div>
-      <ngxd-duration-picker [(value)]="myNumberValue" mode="seconds"></ngxd-duration-picker>
+      <ngx-duration-picker [(value)]="myNumberValue" mode="seconds"></ngx-duration-picker>
     </div>
     <div class="col-xs-6">
       <div class="alert alert-info">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -78,7 +78,7 @@
   <div class="row">
     <div class="col-xs-12">
       <div class="h1">Numeric mode</div>
-      <ngx-duration-picker [(value)]="myNumberValue" mode="seconds"></ngx-duration-picker>
+      <ngx-duration-picker [(value)]="myNumberValue" [options]="{ mode: 'seconds' }"></ngx-duration-picker>
     </div>
     <div class="col-xs-6">
       <div class="alert alert-info">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,7 +3,7 @@
     <div class="col-xs-12">
       <div class="h1">Plain binding</div>
 
-      <app-duration-picker [(value)]="myValue" [disabled]="disabled"></app-duration-picker>
+      <ngxd-duration-picker [(value)]="myValue" [disabled]="disabled"></ngxd-duration-picker>
 
     </div>
     <div class="col-xs-6">
@@ -23,7 +23,7 @@
     <div class="col-xs-12">
       <div class="h1">Reactive Form</div>
       <form [formGroup]="form">
-        <app-duration-picker [formControlName]="'myDurationControl'"></app-duration-picker>
+        <ngxd-duration-picker [formControlName]="'myDurationControl'"></ngxd-duration-picker>
       </form>
     </div>
 
@@ -56,9 +56,9 @@
   <div class="row">
       <div class="col-xs-12">
         <div class="h1">Negative Duration</div>
-  
-        <app-duration-picker [(value)]="myNegativeValue" [options]="{ showNegative: showNegative }"></app-duration-picker>
-  
+
+        <ngxd-duration-picker [(value)]="myNegativeValue" [options]="{ showNegative: showNegative }"></ngxd-duration-picker>
+
       </div>
       <div class="col-xs-6">
         <div class="alert alert-info">
@@ -73,7 +73,20 @@
             <span *ngIf="showNegative">Hide </span>
             Negative Durations</button>
         </div>
-    </div>  
+    </div>
+
+  <div class="row">
+    <div class="col-xs-12">
+      <div class="h1">Numeric mode</div>
+      <ngxd-duration-picker [(value)]="myNumberValue" mode="seconds"></ngxd-duration-picker>
+    </div>
+    <div class="col-xs-6">
+      <div class="alert alert-info">
+        {{ myNumberValue }}
+      </div>
+      <button (click)="myNumberValue = 1234" class="btn btn-info">Set to value '1234'</button>
+    </div>
+  </div>
 </div>
 
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 
 @Component({
-  selector: 'app-root',
+  selector: 'ngxd-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
@@ -10,6 +10,7 @@ export class AppComponent implements OnInit {
 
   myValue;
   myNegativeValue;
+  myNumberValue;
   showNegative = true;
   disabled = false;
   form: FormGroup;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 
 @Component({
-  selector: 'ngxd-root',
+  selector: 'ngx-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })

--- a/src/app/duration-picker/duration-picker.component.spec.ts
+++ b/src/app/duration-picker/duration-picker.component.spec.ts
@@ -1,7 +1,7 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {FormsModule} from '@angular/forms';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 
-import {DurationPickerComponent} from './duration-picker.component';
+import { DurationPickerComponent } from './duration-picker.component';
 
 describe('DurationPickerComponent', () => {
   let component: DurationPickerComponent;
@@ -11,10 +11,10 @@ describe('DurationPickerComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [DurationPickerComponent],
-      imports: [FormsModule],
+      declarations: [ DurationPickerComponent ],
+      imports: [ FormsModule ],
     })
-      .compileComponents();
+    .compileComponents();
   }));
 
   beforeEach(() => {
@@ -133,6 +133,8 @@ describe('DurationPickerComponent', () => {
     });
 
     it('generate() should correctly generate the negative duration values', () => {
+      component.options = {showNegative: true};
+
       set(component, 1, 2, 3, 4, 5, 6, 7, true);
       expect(component.generate()).toBe('-P1Y2M3W4DT5H6M7S');
 
@@ -212,7 +214,7 @@ describe('DurationPickerComponent', () => {
   describe('number mode', () => {
 
     it('generate() should correctly generate the duration values', () => {
-      component.mode = 'seconds';
+      component.options = {mode: 'seconds'};
 
       set(component, 1, 2, 3, 4, 5, 6, 7);
       expect(component.generate()).toBe(38970367);
@@ -241,39 +243,39 @@ describe('DurationPickerComponent', () => {
       set(component, 0, 9, 0, 0, 0, 10, 0);
       expect(component.generate()).toBe(23652600);
 
-      component.mode = 'minutes';
+      component.options = {mode: 'minutes'};
 
       set(component, 0, 0, 0, 0, 1, 10, 0);
       expect(component.generate()).toBe(70);
 
-      component.mode = 'hours';
+      component.options = {mode: 'hours'};
 
       set(component, 0, 0, 0, 2, 11, 0, 0);
       expect(component.generate()).toBe(59);
 
-      component.mode = 'days';
+      component.options = {mode: 'days'};
 
       set(component, 0, 0, 3, 1, 0, 0, 0);
       expect(component.generate()).toBe(22);
 
-      component.mode = 'weeks';
+      component.options = {mode: 'weeks'};
 
       set(component, 0, 0, 4, 0, 0, 0, 0);
       expect(component.generate()).toBe(4);
 
-      component.mode = 'months';
+      component.options = {mode: 'months'};
 
       set(component, 1, 2, 0, 0, 0, 0, 0);
       expect(component.generate()).toBe(14);
 
-      component.mode = 'years';
+      component.options = {mode: 'years'};
 
       set(component, 3, 0, 0, 0, 0, 0, 0);
       expect(component.generate()).toBe(3);
     });
 
     it('generate() should correctly generate the negative duration values', () => {
-      component.mode = 'seconds';
+      component.options = {mode: 'seconds', showNegative: true};
 
       set(component, 1, 2, 3, 4, 5, 6, 7, true);
       expect(component.generate()).toBe(-38970367);
@@ -302,39 +304,39 @@ describe('DurationPickerComponent', () => {
       set(component, 0, 9, 0, 0, 0, 10, 0, true);
       expect(component.generate()).toBe(-23652600);
 
-      component.mode = 'minutes';
+      component.options = {mode: 'minutes', showNegative: true};
 
       set(component, 0, 0, 0, 0, 1, 10, 0, true);
       expect(component.generate()).toBe(-70);
 
-      component.mode = 'hours';
+      component.options = {mode: 'hours', showNegative: true};
 
       set(component, 0, 0, 0, 2, 11, 0, 0, true);
       expect(component.generate()).toBe(-59);
 
-      component.mode = 'days';
+      component.options = {mode: 'days', showNegative: true};
 
       set(component, 0, 0, 3, 1, 0, 0, 0, true);
       expect(component.generate()).toBe(-22);
 
-      component.mode = 'weeks';
+      component.options = {mode: 'weeks', showNegative: true};
 
       set(component, 0, 0, 4, 0, 0, 0, 0, true);
       expect(component.generate()).toBe(-4);
 
-      component.mode = 'months';
+      component.options = {mode: 'months', showNegative: true};
 
       set(component, 1, 2, 0, 0, 0, 0, 0, true);
       expect(component.generate()).toBe(-14);
 
-      component.mode = 'years';
+      component.options = {mode: 'years', showNegative: true};
 
       set(component, 3, 0, 0, 0, 0, 0, 0, true);
       expect(component.generate()).toBe(-3);
     });
 
     it('parse() should correctly parse the input number', () => {
-      component.mode = 'seconds';
+      component.options = {mode: 'seconds'};
       component.value = 38970367;
 
       component.parse();
@@ -382,6 +384,5 @@ function set(
   component.hours = hours;
   component.minutes = minutes;
   component.seconds = seconds;
-  component.config.showNegative = negative;
   component.negative = negative;
 }

--- a/src/app/duration-picker/duration-picker.component.spec.ts
+++ b/src/app/duration-picker/duration-picker.component.spec.ts
@@ -1,7 +1,7 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {FormsModule} from '@angular/forms';
 
-import { DurationPickerComponent } from './duration-picker.component';
+import {DurationPickerComponent} from './duration-picker.component';
 
 describe('DurationPickerComponent', () => {
   let component: DurationPickerComponent;
@@ -11,10 +11,10 @@ describe('DurationPickerComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DurationPickerComponent ],
-      imports: [ FormsModule ],
+      declarations: [DurationPickerComponent],
+      imports: [FormsModule],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -25,121 +25,6 @@ describe('DurationPickerComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('generate() should correctly generate the duration values', () => {
-    set(component, 1, 2, 3, 4, 5, 6, 7);
-    expect(component.generate()).toBe('P1Y2M3W4DT5H6M7S');
-
-    set(component, '1', '2', '3', '4', '5', '6', '7');
-    expect(component.generate()).toBe('P1Y2M3W4DT5H6M7S');
-
-    set(component, 1, 0, 0, 0, 0, 0, 0);
-    expect(component.generate()).toBe('P1Y');
-
-    set(component, 0, 123, 0, 0, 0, 0, 0);
-    expect(component.generate()).toBe('P123M');
-
-    set(component, 0, 0, 3, 0, 0, 0, 0);
-    expect(component.generate()).toBe('P3W');
-
-    set(component, 0, 0, 0, 2, 0, 0, 0);
-    expect(component.generate()).toBe('P2D');
-
-    set(component, 0, 0, 0, 0, 5, 0, 0);
-    expect(component.generate()).toBe('PT5H');
-
-    set(component, 0, 0, 0, 0, 0, 9, 0);
-    expect(component.generate()).toBe('PT9M');
-
-    set(component, 0, 0, 0, 0, 0, 0, 10);
-    expect(component.generate()).toBe('PT10S');
-
-    set(component, 0, 9, 0, 0, 0, 10, 0);
-    expect(component.generate()).toBe('P9MT10M');
-  });
-
-  it('generate() should correctly generate the negative duration values', () => {
-    set(component, 1, 2, 3, 4, 5, 6, 7, true);
-    expect(component.generate()).toBe('-P1Y2M3W4DT5H6M7S');
-
-    set(component, '1', '2', '3', '4', '5', '6', '7', true);
-    expect(component.generate()).toBe('-P1Y2M3W4DT5H6M7S');
-
-    set(component, 1, 0, 0, 0, 0, 0, 0, true);
-    expect(component.generate()).toBe('-P1Y');
-
-    set(component, 0, 123, 0, 0, 0, 0, 0, true);
-    expect(component.generate()).toBe('-P123M');
-
-    set(component, 0, 0, 3, 0, 0, 0, 0, true);
-    expect(component.generate()).toBe('-P3W');
-
-    set(component, 0, 0, 0, 2, 0, 0, 0, true);
-    expect(component.generate()).toBe('-P2D');
-
-    set(component, 0, 0, 0, 0, 5, 0, 0, true);
-    expect(component.generate()).toBe('-PT5H');
-
-    set(component, 0, 0, 0, 0, 0, 9, 0, true);
-    expect(component.generate()).toBe('-PT9M');
-
-    set(component, 0, 0, 0, 0, 0, 0, 10, true);
-    expect(component.generate()).toBe('-PT10S');
-
-    set(component, 0, 9, 0, 0, 0, 10, 0, true);
-    expect(component.generate()).toBe('-P9MT10M');
-  });
-
-  it('generate() should correctly set the zero value according to the configuration', () => {
-    set(component, 0, 0, 0, 0, 0, 0, 0);
-
-    expect(component.generate()).toBe('PT0S');
-
-    set(component, 0, 0, 0, 0, 0, 0, 0, true);
-
-    expect(component.generate()).toBe('PT0S');
-
-    component.config.zeroValue = null;
-    expect(component.generate()).toBe(null);
-
-    component.config.zeroValue = 'myCustomValue';
-    expect(component.generate()).toBe('myCustomValue');
-  });
-
-  it('setting the options should correctly affect the configuration', () => {
-    component.options = { showWeeks: false, showSeconds: true, someNonExistingProperty: 'test' };
-
-    expect(component.config.showWeeks).toBe(false);
-    expect(component.config.showSeconds).toBe(true);
-  });
-
-  it('parse() should correctly parse the ISO8601 string', () => {
-    component.value = 'P1Y2M3W4DT5H6M7S';
-
-    component.parse();
-
-    expect(component.years).toBe(1);
-    expect(component.months).toBe(2);
-    expect(component.weeks).toBe(3);
-    expect(component.days).toBe(4);
-    expect(component.hours).toBe(5);
-    expect(component.minutes).toBe(6);
-    expect(component.seconds).toBe(7);
-    expect(component.negative).toBe(false);
-
-    component.value = '-P1Y2M3W4DT5H6M7S';
-
-    component.parse();
-
-    expect(component.years).toBe(1);
-    expect(component.months).toBe(2);
-    expect(component.weeks).toBe(3);
-    expect(component.days).toBe(4);
-    expect(component.hours).toBe(5);
-    expect(component.minutes).toBe(6);
-    expect(component.seconds).toBe(7);
-    expect(component.negative).toBe(true);
   });
 
   it('parse() should do nothing if the value is null', () => {
@@ -211,6 +96,271 @@ describe('DurationPickerComponent', () => {
     component.writeValue(null);
 
     expect(component.value).toEqual('old value');
+  });
+
+  describe('ISO_8601 mode', () => {
+
+    it('generate() should correctly generate the duration values', () => {
+      set(component, 1, 2, 3, 4, 5, 6, 7);
+      expect(component.generate()).toBe('P1Y2M3W4DT5H6M7S');
+
+      set(component, '1', '2', '3', '4', '5', '6', '7');
+      expect(component.generate()).toBe('P1Y2M3W4DT5H6M7S');
+
+      set(component, 1, 0, 0, 0, 0, 0, 0);
+      expect(component.generate()).toBe('P1Y');
+
+      set(component, 0, 123, 0, 0, 0, 0, 0);
+      expect(component.generate()).toBe('P123M');
+
+      set(component, 0, 0, 3, 0, 0, 0, 0);
+      expect(component.generate()).toBe('P3W');
+
+      set(component, 0, 0, 0, 2, 0, 0, 0);
+      expect(component.generate()).toBe('P2D');
+
+      set(component, 0, 0, 0, 0, 5, 0, 0);
+      expect(component.generate()).toBe('PT5H');
+
+      set(component, 0, 0, 0, 0, 0, 9, 0);
+      expect(component.generate()).toBe('PT9M');
+
+      set(component, 0, 0, 0, 0, 0, 0, 10);
+      expect(component.generate()).toBe('PT10S');
+
+      set(component, 0, 9, 0, 0, 0, 10, 0);
+      expect(component.generate()).toBe('P9MT10M');
+    });
+
+    it('generate() should correctly generate the negative duration values', () => {
+      set(component, 1, 2, 3, 4, 5, 6, 7, true);
+      expect(component.generate()).toBe('-P1Y2M3W4DT5H6M7S');
+
+      set(component, '1', '2', '3', '4', '5', '6', '7', true);
+      expect(component.generate()).toBe('-P1Y2M3W4DT5H6M7S');
+
+      set(component, 1, 0, 0, 0, 0, 0, 0, true);
+      expect(component.generate()).toBe('-P1Y');
+
+      set(component, 0, 123, 0, 0, 0, 0, 0, true);
+      expect(component.generate()).toBe('-P123M');
+
+      set(component, 0, 0, 3, 0, 0, 0, 0, true);
+      expect(component.generate()).toBe('-P3W');
+
+      set(component, 0, 0, 0, 2, 0, 0, 0, true);
+      expect(component.generate()).toBe('-P2D');
+
+      set(component, 0, 0, 0, 0, 5, 0, 0, true);
+      expect(component.generate()).toBe('-PT5H');
+
+      set(component, 0, 0, 0, 0, 0, 9, 0, true);
+      expect(component.generate()).toBe('-PT9M');
+
+      set(component, 0, 0, 0, 0, 0, 0, 10, true);
+      expect(component.generate()).toBe('-PT10S');
+
+      set(component, 0, 9, 0, 0, 0, 10, 0, true);
+      expect(component.generate()).toBe('-P9MT10M');
+    });
+
+    it('generate() should correctly set the zero value according to the configuration', () => {
+      set(component, 0, 0, 0, 0, 0, 0, 0);
+
+      expect(component.generate()).toBe('PT0S');
+
+      set(component, 0, 0, 0, 0, 0, 0, 0, true);
+
+      expect(component.generate()).toBe('PT0S');
+
+      component.config.zeroValue = null;
+      expect(component.generate()).toBe(null);
+
+      component.config.zeroValue = 'myCustomValue';
+      expect(component.generate()).toBe('myCustomValue');
+    });
+
+    it('parse() should correctly parse the ISO8601 string', () => {
+      component.value = 'P1Y2M3W4DT5H6M7S';
+
+      component.parse();
+
+      expect(component.years).toBe(1);
+      expect(component.months).toBe(2);
+      expect(component.weeks).toBe(3);
+      expect(component.days).toBe(4);
+      expect(component.hours).toBe(5);
+      expect(component.minutes).toBe(6);
+      expect(component.seconds).toBe(7);
+      expect(component.negative).toBe(false);
+
+      component.value = '-P1Y2M3W4DT5H6M7S';
+
+      component.parse();
+
+      expect(component.years).toBe(1);
+      expect(component.months).toBe(2);
+      expect(component.weeks).toBe(3);
+      expect(component.days).toBe(4);
+      expect(component.hours).toBe(5);
+      expect(component.minutes).toBe(6);
+      expect(component.seconds).toBe(7);
+      expect(component.negative).toBe(true);
+    });
+  });
+
+  describe('number mode', () => {
+
+    it('generate() should correctly generate the duration values', () => {
+      component.mode = 'seconds';
+
+      set(component, 1, 2, 3, 4, 5, 6, 7);
+      expect(component.generate()).toBe(38970367);
+
+      set(component, 1, 0, 0, 0, 0, 0, 0);
+      expect(component.generate()).toBe(31536000);
+
+      set(component, 0, 123, 0, 0, 0, 0, 0);
+      expect(component.generate()).toBe(323244000);
+
+      set(component, 0, 0, 3, 0, 0, 0, 0);
+      expect(component.generate()).toBe(1814400);
+
+      set(component, 0, 0, 0, 2, 0, 0, 0);
+      expect(component.generate()).toBe(172800);
+
+      set(component, 0, 0, 0, 0, 5, 0, 0);
+      expect(component.generate()).toBe(18000);
+
+      set(component, 0, 0, 0, 0, 0, 9, 0);
+      expect(component.generate()).toBe(540);
+
+      set(component, 0, 0, 0, 0, 0, 0, 10);
+      expect(component.generate()).toBe(10);
+
+      set(component, 0, 9, 0, 0, 0, 10, 0);
+      expect(component.generate()).toBe(23652600);
+
+      component.mode = 'minutes';
+
+      set(component, 0, 0, 0, 0, 1, 10, 0);
+      expect(component.generate()).toBe(70);
+
+      component.mode = 'hours';
+
+      set(component, 0, 0, 0, 2, 11, 0, 0);
+      expect(component.generate()).toBe(59);
+
+      component.mode = 'days';
+
+      set(component, 0, 0, 3, 1, 0, 0, 0);
+      expect(component.generate()).toBe(22);
+
+      component.mode = 'weeks';
+
+      set(component, 0, 0, 4, 0, 0, 0, 0);
+      expect(component.generate()).toBe(4);
+
+      component.mode = 'months';
+
+      set(component, 1, 2, 0, 0, 0, 0, 0);
+      expect(component.generate()).toBe(14);
+
+      component.mode = 'years';
+
+      set(component, 3, 0, 0, 0, 0, 0, 0);
+      expect(component.generate()).toBe(3);
+    });
+
+    it('generate() should correctly generate the negative duration values', () => {
+      component.mode = 'seconds';
+
+      set(component, 1, 2, 3, 4, 5, 6, 7, true);
+      expect(component.generate()).toBe(-38970367);
+
+      set(component, 1, 0, 0, 0, 0, 0, 0, true);
+      expect(component.generate()).toBe(-31536000);
+
+      set(component, 0, 123, 0, 0, 0, 0, 0, true);
+      expect(component.generate()).toBe(-323244000);
+
+      set(component, 0, 0, 3, 0, 0, 0, 0, true);
+      expect(component.generate()).toBe(-1814400);
+
+      set(component, 0, 0, 0, 2, 0, 0, 0, true);
+      expect(component.generate()).toBe(-172800);
+
+      set(component, 0, 0, 0, 0, 5, 0, 0, true);
+      expect(component.generate()).toBe(-18000);
+
+      set(component, 0, 0, 0, 0, 0, 9, 0, true);
+      expect(component.generate()).toBe(-540);
+
+      set(component, 0, 0, 0, 0, 0, 0, 10, true);
+      expect(component.generate()).toBe(-10);
+
+      set(component, 0, 9, 0, 0, 0, 10, 0, true);
+      expect(component.generate()).toBe(-23652600);
+
+      component.mode = 'minutes';
+
+      set(component, 0, 0, 0, 0, 1, 10, 0, true);
+      expect(component.generate()).toBe(-70);
+
+      component.mode = 'hours';
+
+      set(component, 0, 0, 0, 2, 11, 0, 0, true);
+      expect(component.generate()).toBe(-59);
+
+      component.mode = 'days';
+
+      set(component, 0, 0, 3, 1, 0, 0, 0, true);
+      expect(component.generate()).toBe(-22);
+
+      component.mode = 'weeks';
+
+      set(component, 0, 0, 4, 0, 0, 0, 0, true);
+      expect(component.generate()).toBe(-4);
+
+      component.mode = 'months';
+
+      set(component, 1, 2, 0, 0, 0, 0, 0, true);
+      expect(component.generate()).toBe(-14);
+
+      component.mode = 'years';
+
+      set(component, 3, 0, 0, 0, 0, 0, 0, true);
+      expect(component.generate()).toBe(-3);
+    });
+
+    it('parse() should correctly parse the input number', () => {
+      component.mode = 'seconds';
+      component.value = 38970367;
+
+      component.parse();
+
+      expect(component.years).toBe(1);
+      expect(component.months).toBe(2);
+      expect(component.weeks).toBe(3);
+      expect(component.days).toBe(4);
+      expect(component.hours).toBe(5);
+      expect(component.minutes).toBe(6);
+      expect(component.seconds).toBe(7);
+      expect(component.negative).toBe(false);
+
+      component.value = -38970367;
+
+      component.parse();
+
+      expect(component.years).toBe(1);
+      expect(component.months).toBe(2);
+      expect(component.weeks).toBe(3);
+      expect(component.days).toBe(4);
+      expect(component.hours).toBe(5);
+      expect(component.minutes).toBe(6);
+      expect(component.seconds).toBe(7);
+      expect(component.negative).toBe(true);
+    });
   });
 });
 

--- a/src/app/duration-picker/duration-picker.component.ts
+++ b/src/app/duration-picker/duration-picker.component.ts
@@ -1,7 +1,33 @@
-import { Component, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import {Component, EventEmitter, forwardRef, Input, OnInit, Output} from '@angular/core';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
-import { DurationPickerOptions } from './duration-picker';
+import {DurationPickerMode, DurationPickerOptions} from './duration-picker';
+
+const DEFAULT_DURATION_PICKER_MODE: DurationPickerMode = 'ISO_8601';
+const ISO_REGEX: RegExp = /^[+\-]?P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d+[HMS])(\d+H)?(\d+M)?(\d+S)?)?$/;
+const DEFAULT_CONFIG_OPTIONS: DurationPickerOptions = {
+  showNegative: false,
+  showButtons: true,
+  showPreview: true,
+  showLetters: true,
+  showYears: true,
+  showMonths: true,
+  showWeeks: true,
+  showDays: true,
+  showHours: true,
+  showMinutes: true,
+  showSeconds: true,
+  zeroValue: 'PT0S'
+};
+const DURATION_UNITS = {
+  seconds: 1,
+  minutes: 60,
+  hours: 3600,
+  days: 86400,
+  weeks: 604800,
+  months: 2628000,
+  years: 31536000
+};
 
 @Component({
   selector: 'ngxd-duration-picker',
@@ -16,26 +42,29 @@ import { DurationPickerOptions } from './duration-picker';
   ],
 })
 export class DurationPickerComponent implements OnInit, ControlValueAccessor {
-
-  @Input() set options(options) {
-    this.attachChanges(options);
+  @Input() set options(options: DurationPickerOptions) {
+    this.config = {...DEFAULT_CONFIG_OPTIONS, ...options};
   }
 
-  private _value: string;
-
-  get value(): string {
+  get value(): string | number {
     return this._value;
   }
 
   @Input()
-  set value(value: string) {
+  set value(value: string | number) {
     this._value = value;
     this.parse();
   }
 
-  @Output() valueChange = new EventEmitter<string>();
+  get mode(): DurationPickerMode {
+    return this._mode;
+  }
 
-  private _disabled = false;
+  @Input()
+  set mode(mode: DurationPickerMode) {
+    this._mode = mode;
+    this.parse();
+  }
 
   get disabled(): boolean {
     return this._disabled;
@@ -46,95 +75,113 @@ export class DurationPickerComponent implements OnInit, ControlValueAccessor {
     this._disabled = disabled;
   }
 
-  regex: RegExp = /^[\+\-]?P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d+[HMS])(\d+H)?(\d+M)?(\d+S)?)?$/;
+  @Output() valueChange = new EventEmitter<string | number>();
 
+  private _value: string | number;
+  private _mode = DEFAULT_DURATION_PICKER_MODE;
+  private _disabled = false;
   private _negative = false;
-  private _years    = 0;
-  private _months   = 0;
-  private _weeks    = 0;
-  private _days     = 0 ;
-  private _hours    = 0;
-  private _minutes  = 0;
-  private _seconds  = 0;
+  private _years = 0;
+  private _months = 0;
+  private _weeks = 0;
+  private _days = 0;
+  private _hours = 0;
+  private _minutes = 0;
+  private _seconds = 0;
 
-  config: DurationPickerOptions = {
-    showNegative: false,
-    showButtons : true,
-    showPreview : true,
-    showLetters : true,
-    showYears   : true,
-    showMonths  : true,
-    showWeeks   : true,
-    showDays    : true,
-    showHours   : true,
-    showMinutes : true,
-    showSeconds : true,
-    zeroValue   : 'PT0S',
-  };
+  config: DurationPickerOptions = DEFAULT_CONFIG_OPTIONS;
 
-  get negative() { return this._negative; }
+  get negative() {
+    return this._negative;
+  }
+
   set negative(value) {
     this._negative = value;
     this.emitNewValue();
   }
 
-  get years() { return this._years; }
+  get years() {
+    return this._years;
+  }
+
   set years(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._years = value;
     this.emitNewValue();
   }
 
-  get months() { return this._months; }
+  get months() {
+    return this._months;
+  }
+
   set months(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._months = value;
     this.emitNewValue();
   }
 
-  get weeks() { return this._weeks; }
+  get weeks() {
+    return this._weeks;
+  }
+
   set weeks(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._weeks = value;
     this.emitNewValue();
   }
 
-  get days() { return this._days; }
+  get days() {
+    return this._days;
+  }
+
   set days(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._days = value;
     this.emitNewValue();
   }
 
-  get hours() { return this._hours; }
+  get hours() {
+    return this._hours;
+  }
+
   set hours(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._hours = value;
     this.emitNewValue();
   }
 
-  get minutes() { return this._minutes; }
+  get minutes() {
+    return this._minutes;
+  }
+
   set minutes(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._minutes = value;
     this.emitNewValue();
   }
 
-  get seconds() { return this._seconds; }
+  get seconds() {
+    return this._seconds;
+  }
+
   set seconds(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._seconds = value;
     this.emitNewValue();
   }
 
-  onChange = (_: any) => {};
-  onTouched = () => {};
-
-  constructor() { }
+  constructor() {
+  }
 
   ngOnInit() {
     this.parse();
     this.value = this.generate();
+  }
+
+  onChange(_: any) {
+  }
+
+  onTouched() {
   }
 
   registerOnChange(fn) {
@@ -156,74 +203,106 @@ export class DurationPickerComponent implements OnInit, ControlValueAccessor {
   }
 
   parse() {
-    if (!this.value) {
+    if (!this.value || !this.mode) {
       return;
     }
 
-    const match = this.regex.exec(this.value);
+    if (this.mode === 'ISO_8601') {
+      const match = ISO_REGEX.exec(this.value as string);
 
-    if (!match) {
-      console.error(`DurationPicker: invalid initial value: ${this.value}`);
-      return;
+      if (!match) {
+        console.error(`DurationPicker: invalid initial value: ${this.value}`);
+        return;
+      }
+
+      this._negative = match[0].startsWith('-');
+      this._years = this.parseNumber(match[1]);
+      this._months = this.parseNumber(match[2]);
+      this._weeks = this.parseNumber(match[3]);
+      this._days = this.parseNumber(match[4]);
+      this._hours = this.parseNumber(match[6]);
+      this._minutes = this.parseNumber(match[7]);
+      this._seconds = this.parseNumber(match[8]);
+    } else {
+      const baseValue = DURATION_UNITS[this.mode];
+      let numberValue = (this.value as number) * baseValue;
+      this._negative = numberValue < 0;
+      numberValue = numberValue < 0 ? (numberValue * -1) : numberValue;
+      this._years = Math.floor(numberValue / DURATION_UNITS.years);
+      numberValue = numberValue - (this._years * DURATION_UNITS.years);
+      this._months = Math.floor(numberValue / DURATION_UNITS.months);
+      numberValue = numberValue - (this._months * DURATION_UNITS.months);
+      this._weeks = Math.floor(numberValue / DURATION_UNITS.weeks);
+      numberValue = numberValue - (this._weeks * DURATION_UNITS.weeks);
+      this._days = Math.floor(numberValue / DURATION_UNITS.days);
+      numberValue = numberValue - (this._days * DURATION_UNITS.days);
+      this._hours = Math.floor(numberValue / DURATION_UNITS.hours);
+      numberValue = numberValue - (this._hours * DURATION_UNITS.hours);
+      this._minutes = Math.floor(numberValue / DURATION_UNITS.minutes);
+      numberValue = numberValue - (this._minutes * DURATION_UNITS.minutes);
+      this._seconds = Math.floor(numberValue / DURATION_UNITS.seconds);
     }
-
-    this._negative  = match[0].startsWith('-');
-    this._years    = this.parseNumber(match[1]);
-    this._months   = this.parseNumber(match[2]);
-    this._weeks    = this.parseNumber(match[3]);
-    this._days     = this.parseNumber(match[4]);
-    this._hours    = this.parseNumber(match[6]);
-    this._minutes  = this.parseNumber(match[7]);
-    this._seconds  = this.parseNumber(match[8]);
   }
 
   parseNumber(value): number {
     return value ? parseInt(value, 10) : 0;
   }
 
-  generate(): string {
-    let output = 'P';
+  generate(): string | number {
+    if (this.mode === 'ISO_8601') {
+      let output = 'P';
 
-    if (this.config.showNegative && this.negative) {
-      output = '-' + output;
-    }
-
-    if (this.config.showYears && this.years) {
-      output += `${this.years}Y`;
-    }
-    if (this.config.showMonths && this.months) {
-      output += `${this.months}M`;
-    }
-    if (this.config.showWeeks && this.weeks) {
-      output += `${this.weeks}W`;
-    }
-    if (this.config.showDays && this.days) {
-      output += `${this.days}D`;
-    }
-    if (
-      (this.config.showHours && this.hours)
-      || (this.config.showMinutes && this.minutes)
-      || (this.config.showSeconds && this.seconds)
-    ) {
-      output += 'T';
-
-      if (this.config.showHours && this.hours) {
-        output += `${this.hours}H`;
+      if (this.config.showNegative && this.negative) {
+        output = '-' + output;
       }
-      if (this.config.showMinutes && this.minutes) {
-        output += `${this.minutes}M`;
-      }
-      if (this.config.showSeconds && this.seconds) {
-        output += `${this.seconds}S`;
-      }
-    }
 
-    // if all values are empty, just output null
-    if (output === 'P' || output === '-P') {
-      output = this.config.zeroValue;
-    }
+      if (this.config.showYears && this.years) {
+        output += `${this.years}Y`;
+      }
+      if (this.config.showMonths && this.months) {
+        output += `${this.months}M`;
+      }
+      if (this.config.showWeeks && this.weeks) {
+        output += `${this.weeks}W`;
+      }
+      if (this.config.showDays && this.days) {
+        output += `${this.days}D`;
+      }
+      if (
+        (this.config.showHours && this.hours)
+        || (this.config.showMinutes && this.minutes)
+        || (this.config.showSeconds && this.seconds)
+      ) {
+        output += 'T';
 
-    return output;
+        if (this.config.showHours && this.hours) {
+          output += `${this.hours}H`;
+        }
+        if (this.config.showMinutes && this.minutes) {
+          output += `${this.minutes}M`;
+        }
+        if (this.config.showSeconds && this.seconds) {
+          output += `${this.seconds}S`;
+        }
+      }
+
+      // if all values are empty, just output null
+      if (output === 'P' || output === '-P') {
+        output = this.config.zeroValue;
+      }
+
+      return output;
+    } else {
+      const currentValueInSeconds = (this.years * DURATION_UNITS.years) +
+        (this.months * DURATION_UNITS.months) +
+        (this.weeks * DURATION_UNITS.weeks) +
+        (this.days * DURATION_UNITS.days) +
+        (this.hours * DURATION_UNITS.hours) +
+        (this.minutes * DURATION_UNITS.minutes) +
+        (this.seconds * DURATION_UNITS.seconds);
+      const duration = Math.floor(currentValueInSeconds / DURATION_UNITS[this.mode]);
+      return this.config.showNegative && this.negative ? (duration * -1) : duration;
+    }
   }
 
   emitNewValue() {
@@ -231,14 +310,5 @@ export class DurationPickerComponent implements OnInit, ControlValueAccessor {
     this.valueChange.emit(this.value);
     this.onTouched();
     this.onChange(this.value);
-  }
-
-  // Attach all the changes received in the options object
-  attachChanges(options: any): void {
-    Object.keys(options).forEach(param => {
-      if (this.config.hasOwnProperty(param)) {
-        (this.config)[param] = options[param];
-      }
-    });
   }
 }

--- a/src/app/duration-picker/duration-picker.component.ts
+++ b/src/app/duration-picker/duration-picker.component.ts
@@ -30,7 +30,7 @@ const DURATION_UNITS = {
 };
 
 @Component({
-  selector: 'ngxd-duration-picker',
+  selector: 'ngx-duration-picker',
   templateUrl: './duration-picker.component.html',
   styleUrls: ['./duration-picker.component.css'],
   providers: [

--- a/src/app/duration-picker/duration-picker.component.ts
+++ b/src/app/duration-picker/duration-picker.component.ts
@@ -1,9 +1,8 @@
-import {Component, EventEmitter, forwardRef, Input, OnInit, Output} from '@angular/core';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
+import { Component, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import {DurationPickerMode, DurationPickerOptions} from './duration-picker';
+import { DurationPickerOptions } from './duration-picker';
 
-const DEFAULT_DURATION_PICKER_MODE: DurationPickerMode = 'ISO_8601';
 const ISO_REGEX: RegExp = /^[+\-]?P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d+[HMS])(\d+H)?(\d+M)?(\d+S)?)?$/;
 const DEFAULT_CONFIG_OPTIONS: DurationPickerOptions = {
   showNegative: false,
@@ -17,7 +16,8 @@ const DEFAULT_CONFIG_OPTIONS: DurationPickerOptions = {
   showHours: true,
   showMinutes: true,
   showSeconds: true,
-  zeroValue: 'PT0S'
+  zeroValue: 'PT0S',
+  mode: 'ISO_8601'
 };
 const DURATION_UNITS = {
   seconds: 1,
@@ -44,6 +44,7 @@ const DURATION_UNITS = {
 export class DurationPickerComponent implements OnInit, ControlValueAccessor {
   @Input() set options(options: DurationPickerOptions) {
     this.config = {...DEFAULT_CONFIG_OPTIONS, ...options};
+    this.parse();
   }
 
   get value(): string | number {
@@ -53,16 +54,6 @@ export class DurationPickerComponent implements OnInit, ControlValueAccessor {
   @Input()
   set value(value: string | number) {
     this._value = value;
-    this.parse();
-  }
-
-  get mode(): DurationPickerMode {
-    return this._mode;
-  }
-
-  @Input()
-  set mode(mode: DurationPickerMode) {
-    this._mode = mode;
     this.parse();
   }
 
@@ -78,7 +69,6 @@ export class DurationPickerComponent implements OnInit, ControlValueAccessor {
   @Output() valueChange = new EventEmitter<string | number>();
 
   private _value: string | number;
-  private _mode = DEFAULT_DURATION_PICKER_MODE;
   private _disabled = false;
   private _negative = false;
   private _years = 0;
@@ -89,99 +79,71 @@ export class DurationPickerComponent implements OnInit, ControlValueAccessor {
   private _minutes = 0;
   private _seconds = 0;
 
-  config: DurationPickerOptions = DEFAULT_CONFIG_OPTIONS;
+  config: DurationPickerOptions = {...DEFAULT_CONFIG_OPTIONS};
 
-  get negative() {
-    return this._negative;
-  }
-
+  get negative() { return this._negative; }
   set negative(value) {
     this._negative = value;
     this.emitNewValue();
   }
 
-  get years() {
-    return this._years;
-  }
-
+  get years() { return this._years; }
   set years(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._years = value;
     this.emitNewValue();
   }
 
-  get months() {
-    return this._months;
-  }
-
+  get months() { return this._months; }
   set months(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._months = value;
     this.emitNewValue();
   }
 
-  get weeks() {
-    return this._weeks;
-  }
-
+  get weeks() { return this._weeks; }
   set weeks(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._weeks = value;
     this.emitNewValue();
   }
 
-  get days() {
-    return this._days;
-  }
-
+  get days() { return this._days; }
   set days(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._days = value;
     this.emitNewValue();
   }
 
-  get hours() {
-    return this._hours;
-  }
-
+  get hours() { return this._hours; }
   set hours(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._hours = value;
     this.emitNewValue();
   }
 
-  get minutes() {
-    return this._minutes;
-  }
-
+  get minutes() { return this._minutes; }
   set minutes(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._minutes = value;
     this.emitNewValue();
   }
 
-  get seconds() {
-    return this._seconds;
-  }
-
+  get seconds() { return this._seconds; }
   set seconds(value) {
     value = this.parseNumber(value) > 0 ? value : 0;
     this._seconds = value;
     this.emitNewValue();
   }
 
-  constructor() {
-  }
+  onChange = (_: any) => {};
+  onTouched = () => {};
+
+  constructor() { }
 
   ngOnInit() {
     this.parse();
     this.value = this.generate();
-  }
-
-  onChange(_: any) {
-  }
-
-  onTouched() {
   }
 
   registerOnChange(fn) {
@@ -202,106 +164,120 @@ export class DurationPickerComponent implements OnInit, ControlValueAccessor {
     this.disabled = isDisabled;
   }
 
-  parse() {
-    if (!this.value || !this.mode) {
-      return;
-    }
-
-    if (this.mode === 'ISO_8601') {
-      const match = ISO_REGEX.exec(this.value as string);
-
-      if (!match) {
-        console.error(`DurationPicker: invalid initial value: ${this.value}`);
-        return;
-      }
-
-      this._negative = match[0].startsWith('-');
-      this._years = this.parseNumber(match[1]);
-      this._months = this.parseNumber(match[2]);
-      this._weeks = this.parseNumber(match[3]);
-      this._days = this.parseNumber(match[4]);
-      this._hours = this.parseNumber(match[6]);
-      this._minutes = this.parseNumber(match[7]);
-      this._seconds = this.parseNumber(match[8]);
-    } else {
-      const baseValue = DURATION_UNITS[this.mode];
-      let numberValue = (this.value as number) * baseValue;
-      this._negative = numberValue < 0;
-      numberValue = numberValue < 0 ? (numberValue * -1) : numberValue;
-      this._years = Math.floor(numberValue / DURATION_UNITS.years);
-      numberValue = numberValue - (this._years * DURATION_UNITS.years);
-      this._months = Math.floor(numberValue / DURATION_UNITS.months);
-      numberValue = numberValue - (this._months * DURATION_UNITS.months);
-      this._weeks = Math.floor(numberValue / DURATION_UNITS.weeks);
-      numberValue = numberValue - (this._weeks * DURATION_UNITS.weeks);
-      this._days = Math.floor(numberValue / DURATION_UNITS.days);
-      numberValue = numberValue - (this._days * DURATION_UNITS.days);
-      this._hours = Math.floor(numberValue / DURATION_UNITS.hours);
-      numberValue = numberValue - (this._hours * DURATION_UNITS.hours);
-      this._minutes = Math.floor(numberValue / DURATION_UNITS.minutes);
-      numberValue = numberValue - (this._minutes * DURATION_UNITS.minutes);
-      this._seconds = Math.floor(numberValue / DURATION_UNITS.seconds);
-    }
-  }
-
   parseNumber(value): number {
     return value ? parseInt(value, 10) : 0;
   }
 
-  generate(): string | number {
-    if (this.mode === 'ISO_8601') {
-      let output = 'P';
+  parseISO8601Value(value: string) {
+    const match = ISO_REGEX.exec(value);
 
-      if (this.config.showNegative && this.negative) {
-        output = '-' + output;
-      }
+    if (!match) {
+      console.error(`DurationPicker: invalid initial value: ${value}`);
+      return;
+    }
 
-      if (this.config.showYears && this.years) {
-        output += `${this.years}Y`;
-      }
-      if (this.config.showMonths && this.months) {
-        output += `${this.months}M`;
-      }
-      if (this.config.showWeeks && this.weeks) {
-        output += `${this.weeks}W`;
-      }
-      if (this.config.showDays && this.days) {
-        output += `${this.days}D`;
-      }
-      if (
-        (this.config.showHours && this.hours)
-        || (this.config.showMinutes && this.minutes)
-        || (this.config.showSeconds && this.seconds)
-      ) {
-        output += 'T';
+    this._negative = match[0].startsWith('-');
+    this._years    = this.parseNumber(match[1]);
+    this._months   = this.parseNumber(match[2]);
+    this._weeks    = this.parseNumber(match[3]);
+    this._days     = this.parseNumber(match[4]);
+    this._hours    = this.parseNumber(match[6]);
+    this._minutes  = this.parseNumber(match[7]);
+    this._seconds  = this.parseNumber(match[8]);
+  }
 
-        if (this.config.showHours && this.hours) {
-          output += `${this.hours}H`;
-        }
-        if (this.config.showMinutes && this.minutes) {
-          output += `${this.minutes}M`;
-        }
-        if (this.config.showSeconds && this.seconds) {
-          output += `${this.seconds}S`;
-        }
-      }
+  parseNumericValue(value: number) {
+    const baseValue = DURATION_UNITS[this.config.mode];
+    let numberValue = value * baseValue;
+    this._negative = numberValue < 0;
+    numberValue = numberValue < 0 ? (numberValue * -1) : numberValue;
+    this._years = Math.floor(numberValue / DURATION_UNITS.years);
+    numberValue = numberValue - (this._years * DURATION_UNITS.years);
+    this._months = Math.floor(numberValue / DURATION_UNITS.months);
+    numberValue = numberValue - (this._months * DURATION_UNITS.months);
+    this._weeks = Math.floor(numberValue / DURATION_UNITS.weeks);
+    numberValue = numberValue - (this._weeks * DURATION_UNITS.weeks);
+    this._days = Math.floor(numberValue / DURATION_UNITS.days);
+    numberValue = numberValue - (this._days * DURATION_UNITS.days);
+    this._hours = Math.floor(numberValue / DURATION_UNITS.hours);
+    numberValue = numberValue - (this._hours * DURATION_UNITS.hours);
+    this._minutes = Math.floor(numberValue / DURATION_UNITS.minutes);
+    numberValue = numberValue - (this._minutes * DURATION_UNITS.minutes);
+    this._seconds = Math.floor(numberValue / DURATION_UNITS.seconds);
+  }
 
-      // if all values are empty, just output null
-      if (output === 'P' || output === '-P') {
-        output = this.config.zeroValue;
+  parse() {
+    if (this.config.mode === 'ISO_8601') {
+      if (this.value) {
+        this.parseISO8601Value(this.value as string);
       }
-
-      return output;
     } else {
-      const currentValueInSeconds = (this.years * DURATION_UNITS.years) +
-        (this.months * DURATION_UNITS.months) +
-        (this.weeks * DURATION_UNITS.weeks) +
-        (this.days * DURATION_UNITS.days) +
-        (this.hours * DURATION_UNITS.hours) +
-        (this.minutes * DURATION_UNITS.minutes) +
-        (this.seconds * DURATION_UNITS.seconds);
-      const duration = Math.floor(currentValueInSeconds / DURATION_UNITS[this.mode]);
-      return this.config.showNegative && this.negative ? (duration * -1) : duration;
+      this.parseNumericValue(this.value as number || 0);
+    }
+  }
+
+  generateISO8601Value(): string {
+    let output = 'P';
+
+    if (this.config.showNegative && this.negative) {
+      output = '-' + output;
+    }
+
+    if (this.config.showYears && this.years) {
+      output += `${this.years}Y`;
+    }
+    if (this.config.showMonths && this.months) {
+      output += `${this.months}M`;
+    }
+    if (this.config.showWeeks && this.weeks) {
+      output += `${this.weeks}W`;
+    }
+    if (this.config.showDays && this.days) {
+      output += `${this.days}D`;
+    }
+    if (
+      (this.config.showHours && this.hours)
+      || (this.config.showMinutes && this.minutes)
+      || (this.config.showSeconds && this.seconds)
+    ) {
+      output += 'T';
+
+      if (this.config.showHours && this.hours) {
+        output += `${this.hours}H`;
+      }
+      if (this.config.showMinutes && this.minutes) {
+        output += `${this.minutes}M`;
+      }
+      if (this.config.showSeconds && this.seconds) {
+        output += `${this.seconds}S`;
+      }
+    }
+
+    // if all values are empty, just output null
+    if (output === 'P' || output === '-P') {
+      output = this.config.zeroValue;
+    }
+
+    return output;
+  }
+
+  generateNumericValue(): number {
+    const currentValueInSeconds = (this.years * DURATION_UNITS.years) +
+      (this.months * DURATION_UNITS.months) +
+      (this.weeks * DURATION_UNITS.weeks) +
+      (this.days * DURATION_UNITS.days) +
+      (this.hours * DURATION_UNITS.hours) +
+      (this.minutes * DURATION_UNITS.minutes) +
+      (this.seconds * DURATION_UNITS.seconds);
+    const duration = Math.floor(currentValueInSeconds / DURATION_UNITS[this.config.mode]);
+    return this.config.showNegative && this.negative ? (duration * -1) : duration;
+  }
+
+  generate(): string | number {
+    if (this.config.mode === 'ISO_8601') {
+      return this.generateISO8601Value();
+    } else {
+      return this.generateNumericValue();
     }
   }
 

--- a/src/app/duration-picker/duration-picker.component.ts
+++ b/src/app/duration-picker/duration-picker.component.ts
@@ -4,7 +4,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { DurationPickerOptions } from './duration-picker';
 
 @Component({
-  selector: 'app-duration-picker',
+  selector: 'ngxd-duration-picker',
   templateUrl: './duration-picker.component.html',
   styleUrls: ['./duration-picker.component.css'],
   providers: [

--- a/src/app/duration-picker/duration-picker.d.ts
+++ b/src/app/duration-picker/duration-picker.d.ts
@@ -13,4 +13,5 @@ export interface DurationPickerOptions {
   showMinutes?: boolean;
   showSeconds?: boolean;
   zeroValue?: string | null;
+  mode?: DurationPickerMode;
 }

--- a/src/app/duration-picker/duration-picker.d.ts
+++ b/src/app/duration-picker/duration-picker.d.ts
@@ -1,14 +1,16 @@
+export type DurationPickerMode = 'ISO_8601' | 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months' | 'years';
+
 export interface DurationPickerOptions {
-  showNegative: boolean;
-  showButtons: boolean;
-  showPreview: boolean;
-  showLetters: boolean;
-  showYears: boolean;
-  showMonths: boolean;
-  showWeeks: boolean;
-  showDays: boolean;
-  showHours: boolean;
-  showMinutes: boolean;
-  showSeconds: boolean;
-  zeroValue: string | null;
+  showNegative?: boolean;
+  showButtons?: boolean;
+  showPreview?: boolean;
+  showLetters?: boolean;
+  showYears?: boolean;
+  showMonths?: boolean;
+  showWeeks?: boolean;
+  showDays?: boolean;
+  showHours?: boolean;
+  showMinutes?: boolean;
+  showSeconds?: boolean;
+  zeroValue?: string | null;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <app-root></app-root>
+  <ngxd-root></ngxd-root>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <ngxd-root></ngxd-root>
+  <ngx-root></ngx-root>
 </body>
 </html>

--- a/tslint.json
+++ b/tslint.json
@@ -117,13 +117,13 @@
     "directive-selector": [
       true,
       "attribute",
-      "ngxd",
+      "ngx",
       "camelCase"
     ],
     "component-selector": [
       true,
       "element",
-      "ngxd",
+      "ngx",
       "kebab-case"
     ],
     "use-input-property-decorator": true,

--- a/tslint.json
+++ b/tslint.json
@@ -117,13 +117,13 @@
     "directive-selector": [
       true,
       "attribute",
-      "app",
+      "ngxd",
       "camelCase"
     ],
     "component-selector": [
       true,
       "element",
-      "app",
+      "ngxd",
       "kebab-case"
     ],
     "use-input-property-decorator": true,


### PR DESCRIPTION
- Renames the component to have a different prefix as 3rd party libs shouldn't use `app`.
- Allows specifying a different `mode` as seconds/minutes/hours/days/weeks/months/years which will allow the input to be a numeric type.

ISO8601 durations are great, but a lot of APIs use seconds for example to express duration and it would be nice to not have to bring in something like moment.js to translate the durations before submitting the value to the API.